### PR TITLE
Fix for supervisor name and docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add Boltun as a dependency in your `mix.exs` file.
 
 ```elixir
 defp deps do
-  [{:boltun, "~> 0.0.1"}]
+  [{:boltun, "~> 1.0.1"}]
 end
 ```
 

--- a/lib/boltun/supervisor.ex
+++ b/lib/boltun/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Boltun.Supervisor do
   Starts the Boltun supervision tree. The options are:
   * `connection`: the connection parameters
   * `name`: the base name to register the process.
-  * `callbacks': the initial callbacks (optional)
+  * `callbacks`: the initial callbacks (optional)
 
   The supervisor will register each started process by using the provided name and concatenating
   a dot and the following suffixes:

--- a/lib/boltun/supervisor.ex
+++ b/lib/boltun/supervisor.ex
@@ -14,7 +14,7 @@ defmodule Boltun.Supervisor do
   * `Listener` the actual listener. You can use this to manage active callbacks
   """
   def start_link(opts) do
-    Supervisor.start_link(__MODULE__, opts)
+    Supervisor.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Boltun.Mixfile do
 
   def project do
     [app: :boltun,
-     version: "1.0.0",
+     version: "1.0.1",
      elixir: "~> 1.0",
      deps: deps,
      package: package,


### PR DESCRIPTION
Earlier the supervisor started by the module `using` Boltun would be unnamed. Changed it to the module name.

This would help in killing/stopping the supervisor when required. In my case, I needed to stop it, while recreating db during my tests.
